### PR TITLE
Firefox returns Time property as null so parsing doesn't work.

### DIFF
--- a/src/HarSharp/Entry.cs
+++ b/src/HarSharp/Entry.cs
@@ -29,7 +29,7 @@ namespace HarSharp
         /// This is the sum of all timings available in the timings object.
         /// </remarks>
         /// </summary>
-        public double Time { get; set; }
+        public double? Time { get; set; }
 
         /// <summary>
         /// Gets or sets the detailed info about the request.


### PR DESCRIPTION
Hi,

I tried to use this lib with har created in firefox. However I was not successful since ff returns time as null. Here is snippet of har data.
```
	"entries": [{
				"pageref": "page_2",
				"startedDateTime": "2018-03-12T08:13:09.921+01:00",
				"time": null,
				"request": {
					"bodySize": 0,
					"method": "GET",
					"url": "https://github.com/giacomelli/HarSharp",
					"httpVersion": "HTTP/1.1",

```
This fix just marks property as nullable double which is enough to parse har.